### PR TITLE
Adding alt-text to avatar output

### DIFF
--- a/includes/class-hcard-user.php
+++ b/includes/class-hcard-user.php
@@ -526,7 +526,7 @@ class HCard_User {
 				$user,
 				$args['avatar_size'],
 				'default',
-				'',
+				$user->get( 'display_name' ),
 				array(
 					'class' => array( 'u-photo', 'hcard-photo' ),
 				)


### PR DESCRIPTION
Missing Alt-text gets flagged as an accessibility issue. This adds the display_name property as the value instead of leaving it empty.